### PR TITLE
Edit typo in OSPL_URI

### DIFF
--- a/ups/ts_opensplice.table
+++ b/ups/ts_opensplice.table
@@ -1,5 +1,5 @@
 envSet(OSPL_HOME, "${PRODUCT_DIR}/OpenSpliceDDS/V6.4.1/HDE/x86_64.linux")
-envSet(OSPL_URI, "file://${OSPL_HOME}/config/ospl.xml")
+envSet(OSPL_URI, "file://${OSPL_HOME}/etc/config/ospl.xml")
 envSet(OSPL_TMPL_PATH, ${OSPL_HOME}/etc/idlpp)
 
 envSet(SPLICE_ORB, DDS_OpenFusion_2)


### PR DESCRIPTION
The default OSPL_URI set in the ups.table file was incorrect, but should now be fixed.