### PR TITLE
Remove bug inducing heartbeat thread stack size

### DIFF
--- a/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux-debug/etc/config/ospl.xml
+++ b/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux-debug/etc/config/ospl.xml
@@ -47,13 +47,6 @@
                </Scheduling>
                <StackSize>6000000</StackSize>
             </ResendManager>
-            <Heartbeat>
-               <Scheduling>
-                  <Class>Default</Class>
-                  <Priority>0</Priority>
-               </Scheduling>
-               <StackSize>6000000</StackSize>
-            </Heartbeat>
          </Daemon>
          <Listeners>
             <StackSize>6000000</StackSize>


### PR DESCRIPTION
Remove section from ospl.xml which was triggering a bug on dds shutdown sometimes.